### PR TITLE
bug fixed in name comparison in MatchesFinder

### DIFF
--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
@@ -55,7 +55,7 @@ public class MatchesFinder {
 
 			String scoreString = String.format("%d", score);
 
-			if (score >= 1) {
+			if (score >= 20) {
 				if (!selectedProfilesList.containsKey(scoreString)) {
 					selectedProfilesList.put(scoreString, new ArrayList<>());
 				}
@@ -82,12 +82,18 @@ public class MatchesFinder {
 				count++;
 			}
 		}
+		
 		if (count == splitedFilteredName.length) return splitedFilteredName;
+		
 		String[] resizedSplitedFilteredName = new String[count];
-		for (int i = 0; i < count; i++) {
-			resizedSplitedFilteredName[i] = splitedFilteredName[i];
+		int index = 0;
+		for (String filteredName : splitedFilteredName) {
+			if (filteredName != null) {
+				resizedSplitedFilteredName[index] = filteredName;
+				index++;
+			}
 		}
-		return splitedFilteredName;
+		return resizedSplitedFilteredName;
 	}
 
 	private String[] normalize(String[] rawName) {
@@ -104,7 +110,7 @@ public class MatchesFinder {
 		for (String name1 : namesToCompare) {
 			for (String name2 : names) {
 				if (name1 != null && name2 != null && name1.equals(name2)) {
-					score += 20;
+					score += 10;
 				}
 			}
 		}
@@ -192,7 +198,7 @@ public class MatchesFinder {
 			String name = school.getNames()[i];
 
 			if (name.equals(schoolUrl)) {
-				score += 20;
+				score += 10;
 			} else {
 				continue;
 			}

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
@@ -55,7 +55,7 @@ public class MatchesFinder {
 
 			String scoreString = String.format("%d", score);
 
-			if (score >= 20) {
+			if (score >= 1) {
 				if (!selectedProfilesList.containsKey(scoreString)) {
 					selectedProfilesList.put(scoreString, new ArrayList<>());
 				}
@@ -165,6 +165,11 @@ public class MatchesFinder {
 		ParsedName linkedinParsedName = getParsedName(linkedinName);
 
 		int score = 0;
+		
+		if (alumniParsedName.isComposed()) {
+			linkedinParsedName.turnComposed();
+		}
+		
 		score += compareNames(alumniParsedName.getNames(), linkedinParsedName.getNames());
 		score += compareNames(alumniParsedName.getSurnames(), linkedinParsedName.getSurnames());
 

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
@@ -78,21 +78,17 @@ public class MatchesFinder {
 		for (int i = 0; i < splitedName.length; i++) {
 			String namePart = splitedName[i];
 			if (!connectors.contains(namePart)) {
-				splitedFilteredName[i] = namePart;
-				count++;
+				splitedFilteredName[count++] = namePart;
 			}
 		}
 		
 		if (count == splitedFilteredName.length) return splitedFilteredName;
 		
 		String[] resizedSplitedFilteredName = new String[count];
-		int index = 0;
-		for (String filteredName : splitedFilteredName) {
-			if (filteredName != null) {
-				resizedSplitedFilteredName[index] = filteredName;
-				index++;
-			}
+		for (int i = 0; i < count; i++) {
+			resizedSplitedFilteredName[i] = splitedFilteredName[i];
 		}
+		
 		return resizedSplitedFilteredName;
 	}
 

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/models/ParsedName.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/models/ParsedName.java
@@ -43,6 +43,10 @@ public class ParsedName {
 	}
 	
 	public void turnComposed() {
+		if (isComposed()) {
+			return;
+		}
+		
 		this.names = new String[] { this.names[0], this.surnames[0] };
 		
 		this.surnames = new String[this.surnames.length - 1];

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/models/ParsedName.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/models/ParsedName.java
@@ -37,6 +37,19 @@ public class ParsedName {
 	public void setSuffix(String suffix) {
 		this.suffix = suffix;
 	}
+	
+	public boolean isComposed() {
+		return names.length >= 2;
+	}
+	
+	public void turnComposed() {
+		this.names = new String[] { this.names[0], this.surnames[0] };
+		
+		this.surnames = new String[this.surnames.length - 1];
+		for (int i = 1; i < this.surnames.length; i++) {
+			this.surnames[i - 1] = this.surnames[i];
+		}
+	}
 
 	@Override
 	public int hashCode() {


### PR DESCRIPTION
O método comparava corretamente mas retornava o vetor de nomes errado. Além disso, ao verificar se era conectivo, no vetor de nomes constava como null, por isso só foi incluído no vetor filtrado elementos não nulos.