### PR TITLE
added sorting to pending matches

### DIFF
--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/ApplicationFacade.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/ApplicationFacade.java
@@ -61,7 +61,7 @@ public class ApplicationFacade {
 
     public Page<PendingMatch> getAlumniPendingMatches(String token, int page) throws EurecaException {
         authenticateAndAuthorize(token, AlumniOperation.GET_ALUMNI_PENDING_MATCHES);
-        return MatchesHolder.getInstance().getPendingMatchesPage(page);
+        return MatchesHolder.getInstance().getPendingMatchesPage(page, "matches");
     }
 
     public void setMatch(String token, String registration, String linkedinId) throws EurecaException {

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/models/PendingMatch.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/models/PendingMatch.java
@@ -1,15 +1,14 @@
 package br.edu.ufcg.computacao.alumni.core.models;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.TreeMap;
-
 import br.edu.ufcg.computacao.alumni.api.http.response.LinkedinAlumnusData;
 import br.edu.ufcg.computacao.alumni.api.http.response.UfcgAlumnusData;
 import br.edu.ufcg.computacao.alumni.core.util.ScoreComparator;
 
-public class PendingMatch {
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
 
+public class PendingMatch {
 	private UfcgAlumnusData alumnus;
 	private Map<String, Collection<LinkedinAlumnusData>> possibleMatches;
 	
@@ -53,5 +52,5 @@ public class PendingMatch {
 			return false;
 		return true;
 	}
-	
+
 }

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/models/SortMethod.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/models/SortMethod.java
@@ -1,0 +1,30 @@
+package br.edu.ufcg.computacao.alumni.core.models;
+
+public enum SortMethod {
+
+    NAME("name"),
+    NUMBER_OF_MATCHES("matches");
+
+    private String strategy;
+
+    private SortMethod(String strategy) {
+        this.strategy = strategy;
+    }
+
+    public String getStrategy() {
+        return strategy;
+    }
+
+    public static SortMethod toEnum(String strategy) {
+        if (strategy == null) {
+            return null;
+        }
+
+        for (SortMethod sortMethod : SortMethod.values()) {
+            if (sortMethod.getStrategy().equals(strategy)) {
+                return sortMethod;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/MatchesFinderProcessor.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/MatchesFinderProcessor.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import br.edu.ufcg.computacao.eureca.common.exceptions.FatalErrorException;
-import br.edu.ufcg.computacao.eureca.common.util.HomeDir;
 import org.apache.log4j.Logger;
 
 import br.edu.ufcg.computacao.alumni.api.http.response.LinkedinAlumnusData;
@@ -25,6 +23,8 @@ import br.edu.ufcg.computacao.alumni.core.holders.PropertiesHolder;
 import br.edu.ufcg.computacao.alumni.core.models.DateRange;
 import br.edu.ufcg.computacao.alumni.core.models.PendingMatch;
 import br.edu.ufcg.computacao.alumni.core.models.SchoolName;
+import br.edu.ufcg.computacao.eureca.common.exceptions.FatalErrorException;
+import br.edu.ufcg.computacao.eureca.common.util.HomeDir;
 
 public class MatchesFinderProcessor extends Thread {
 	private Logger LOGGER = Logger.getLogger(MatchesFinderProcessor.class);
@@ -72,7 +72,7 @@ public class MatchesFinderProcessor extends Thread {
 		
 		return new SchoolName(names, dateRanges);
 	}
-
+	
 	@Override
 	public void run() {
 		boolean isActive = true;

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/util/PendingMatchNameComparator.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/util/PendingMatchNameComparator.java
@@ -1,0 +1,11 @@
+package br.edu.ufcg.computacao.alumni.core.util;
+
+import br.edu.ufcg.computacao.alumni.core.models.PendingMatch;
+
+public class PendingMatchNameComparator implements SortStrategy {
+
+    @Override
+    public int compare(PendingMatch p1, PendingMatch p2) {
+        return p1.getAlumnus().getFullName().toLowerCase().compareTo(p2.getAlumnus().getFullName().toLowerCase());
+    }
+}

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/util/PendingMatchNumberComparator.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/util/PendingMatchNumberComparator.java
@@ -1,0 +1,11 @@
+package br.edu.ufcg.computacao.alumni.core.util;
+
+import br.edu.ufcg.computacao.alumni.core.models.PendingMatch;
+
+public class PendingMatchNumberComparator implements SortStrategy {
+
+    @Override
+    public int compare(PendingMatch p1, PendingMatch p2) {
+        return Integer.compare(p1.getPossibleMatches().size(), p2.getPossibleMatches().size());
+    }
+}

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/util/SortStrategy.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/util/SortStrategy.java
@@ -1,0 +1,8 @@
+package br.edu.ufcg.computacao.alumni.core.util;
+
+import br.edu.ufcg.computacao.alumni.core.models.PendingMatch;
+
+import java.util.Comparator;
+
+public interface SortStrategy extends Comparator<PendingMatch> {
+}

--- a/src/test/java/br/edu/ufcg/educacao/alumni/core/MatchesFinderTest.java
+++ b/src/test/java/br/edu/ufcg/educacao/alumni/core/MatchesFinderTest.java
@@ -1,0 +1,107 @@
+package br.edu.ufcg.educacao.alumni.core;
+
+import br.edu.ufcg.computacao.alumni.api.http.response.LinkedinAlumnusData;
+import br.edu.ufcg.computacao.alumni.api.http.response.UfcgAlumnusData;
+import br.edu.ufcg.computacao.alumni.core.MatchesFinder;
+import br.edu.ufcg.computacao.alumni.core.holders.LinkedinDataHolder;
+import br.edu.ufcg.computacao.alumni.core.models.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(SpringRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
+@PrepareForTest(MatchesFinder.class)
+public class MatchesFinderTest {
+
+	private MatchesFinder matchesFinder;
+
+	@Before
+	public void setUp() {
+		this.matchesFinder = Mockito.spy(MatchesFinder.class);
+	}
+	
+	@Test
+	public void testMock() {
+		UfcgAlumnusData fakeAlumnus = createFakeAlumnus();
+		SchoolName fakeSchool = createFakeSchool();
+		Map<String, Collection<LinkedinAlumnusData>> fakeMatches = createFakeMatches();
+
+		Mockito.doReturn(fakeMatches).when(this.matchesFinder).findMatches(fakeAlumnus, fakeSchool);
+
+		Assert.assertEquals(createFakeMatches(), this.matchesFinder.findMatches(fakeAlumnus, fakeSchool));
+		Mockito.verify(this.matchesFinder, Mockito.times(1)).findMatches(Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	public void testOne() {
+
+	}
+
+	@Test
+	public void testNullInputFromConfFile() {
+		Mockito.doReturn(null).when(this.matchesFinder).findMatches(null, createFakeSchool());
+
+		Assert.assertNull(this.matchesFinder.findMatches(null, createFakeSchool()));
+		Mockito.verify(this.matchesFinder, Mockito.times(1)).findMatches(Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	public void testFindRealMatch() {
+		UfcgAlumnusData hugoRaniere = getRealAlumnus();
+		Map<String, Collection<String>> realMatches = getRealMatches();
+
+		Mockito.doReturn(realMatches).when(this.matchesFinder).findMatches(hugoRaniere, Mockito.any());
+
+		MatchesFinder realMatchesFinder = MatchesFinder.getInstance();
+		List<LinkedinAlumnusData> matches = new ArrayList<>(realMatchesFinder.findMatches(hugoRaniere, new SchoolName(new String[]{}, new DateRange[]{})).get("60"));
+		String linkedinUrl = matches.get(0).getLinkedinProfile();
+
+		Assert.assertTrue(this.matchesFinder.findMatches(hugoRaniere, new SchoolName(new String[] {}, new DateRange[] {})).get("60").stream().map(LinkedinAlumnusData::getLinkedinProfile).collect(Collectors.toList()).contains(linkedinUrl));
+	}
+
+	private Map<String, Collection<String>> getRealMatches() {
+		Map<String, Collection<String>> map = new HashMap<>();
+		map.put("60", Arrays.asList("https://www.linkedin.com/in/hugoraniere"));
+		return map;
+	}
+
+	private UfcgAlumnusData getRealAlumnus() {
+		return new UfcgAlumnusData("100110002", "HUGO RANIERE DI ASSUNCAO BRASILINO", getRealDegrees());
+	}
+
+	private Degree[] getRealDegrees() {
+		return new Degree[] {
+				new Degree(CourseName.COMPUTING_SCIENCE, Level.UNDERGRADUATE, "2001.1", "2005.2")
+		};
+	}
+
+	private UfcgAlumnusData createFakeAlumnus() {
+		return new UfcgAlumnusData("fake registration", "fake name", new Degree[] {});
+	}
+	
+	private SchoolName createFakeSchool() {
+		return new SchoolName(new String[] { "fake school name "}, new DateRange[] {});
+	}
+	
+	private LinkedinAlumnusData createFakeLinkedinAlumnus() {
+		return new LinkedinAlumnusData("fake full name", "fake company", "fake description", "fake location", new LinkedinJobData[] {}, new LinkedinSchoolData[] {}, "fake email", "fake linkedin profile", "fake twitter id");
+	}
+	
+	private Map<String, Collection<LinkedinAlumnusData>> createFakeMatches() {
+		Map<String, Collection<LinkedinAlumnusData>> map = new HashMap<>();
+		map.put("30", Arrays.asList(createFakeLinkedinAlumnus(), createFakeLinkedinAlumnus()));
+		return map;
+	}
+}


### PR DESCRIPTION
Adicionei duas formas de ordenar os mapeamentos buscados: Em ordem alfabética e ordenados pela quantidade de matches. Foi percebido que, quanto menos perfis do Linkedin mapeados com o aluno, maior é a chance de ser o perfil correto, por isso implementei esses dois tipos de ordenação.