### PR TITLE
added getLinkedinId to LinkedinAlumnusData (Issue de Iele)

### DIFF
--- a/src/main/java/br/edu/ufcg/computacao/alumni/api/http/response/LinkedinAlumnusData.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/api/http/response/LinkedinAlumnusData.java
@@ -93,6 +93,11 @@ public class LinkedinAlumnusData {
         return linkedinProfile;
     }
 
+    public String getLinkedinId() {
+        String[] splitedUrl = linkedinProfile.split("/");
+        return splitedUrl[splitedUrl.length - 1];
+    }
+
     public void setLinkedinProfile(String linkedinProfile) {
         this.linkedinProfile = linkedinProfile;
     }

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
@@ -109,6 +109,7 @@ public class MatchesFinder {
 	}
 
 	private ParsedName getParsedName(String name) {
+		name = deAccent(name);
 		String[] names = new String[0];
 		String[] surnames = new String [0];
 		String suffix = null;
@@ -150,16 +151,13 @@ public class MatchesFinder {
 	}
 
 	private int getScoreFromName(String alumniName, String linkedinName) {
-		alumniName = deAccent(alumniName);
-		linkedinName = deAccent(linkedinName);
-
-		if (alumniName.equals(linkedinName)) return 200;
-
 		ParsedName alumniParsedName = getParsedName(alumniName);
 		ParsedName linkedinParsedName = getParsedName(linkedinName);
 
+		if (alumniParsedName.equals(linkedinParsedName)) return 200;
+
 		int score = 0;
-		
+
 		if (alumniParsedName.isComposed() && !linkedinParsedName.isComposed()) {
 			linkedinParsedName.turnComposed();
 		}


### PR DESCRIPTION
Ao invés de retornar a url completa do perfil do Linkedin, o método retorna apenas o nome do usuário.