### PR TITLE
Jonatas develop

### DIFF
--- a/src/main/java/br/edu/ufcg/computacao/alumni/api/http/response/LinkedinAlumnusData.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/api/http/response/LinkedinAlumnusData.java
@@ -93,6 +93,11 @@ public class LinkedinAlumnusData {
         return linkedinProfile;
     }
 
+    public String getLinkedinId() {
+        String[] splitedUrl = linkedinProfile.split("/");
+        return splitedUrl[splitedUrl.length - 1];
+    }
+
     public void setLinkedinProfile(String linkedinProfile) {
         this.linkedinProfile = linkedinProfile;
     }

--- a/src/main/java/br/edu/ufcg/computacao/alumni/api/http/response/MatchResponse.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/api/http/response/MatchResponse.java
@@ -6,11 +6,14 @@ import io.swagger.annotations.ApiModelProperty;
 public class MatchResponse {
     @ApiModelProperty(position = 0, example = ApiDocumentation.Model.REGISTRATION)
     private String registration;
-    @ApiModelProperty(position = 1, example = ApiDocumentation.Model.LINKEDIN_ID)
+    @ApiModelProperty(position = 1, example = ApiDocumentation.Model.FULL_NAME)
+    private String fullName;
+    @ApiModelProperty(position = 2, example = ApiDocumentation.Model.LINKEDIN_ID)
     private String linkedinId;
 
-    public MatchResponse(String registration, String linkedinId) {
+    public MatchResponse(String registration, String fullName, String linkedinId) {
         this.registration = registration;
+        this.fullName = fullName;
         this.linkedinId = linkedinId;
     }
 
@@ -20,6 +23,14 @@ public class MatchResponse {
 
     public void setRegistration(String registration) {
         this.registration = registration;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
     }
 
     public String getLinkedinId() {

--- a/src/main/java/br/edu/ufcg/computacao/alumni/constants/ConfigurationPropertyKeys.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/constants/ConfigurationPropertyKeys.java
@@ -2,6 +2,7 @@ package br.edu.ufcg.computacao.alumni.constants;
 
 public class ConfigurationPropertyKeys {
     public static final String LINKEDIN_SOURCE_URL_KEY = "linkedin_source_url";
+    public static final String LINKEDIN_USER_BASE_URL_KEY = "linkedin_user_url";
     public static final String LINKEDIN_INPUT_FILE_KEY = "linkedin_input";
     public static final String ALUMNI_INPUT_FILE_KEY = "alumni_input";
     public static final String ALUMNI_PUBLICKEY_FILE_KEY = "alumni_publickey";

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/ApplicationFacade.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/ApplicationFacade.java
@@ -87,7 +87,7 @@ public class ApplicationFacade {
             throw new InternalServerErrorException(e.getMessage());
         }
     }
-    public List<MatchResponse> getAlumnusMatches(String token, String registration) throws EurecaException {
+    public MatchResponse getAlumnusMatches(String token, String registration) throws EurecaException {
         authenticateAndAuthorize(token, AlumniOperation.GET_ALUMNI_MATCHES);
         return MatchesHolder.getInstance().getAlumnusMatches(registration);
     }

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
@@ -109,6 +109,7 @@ public class MatchesFinder {
 	}
 
 	private ParsedName getParsedName(String name) {
+		name = deAccent(name);
 		String[] names = new String[0];
 		String[] surnames = new String [0];
 		String suffix = null;
@@ -150,16 +151,13 @@ public class MatchesFinder {
 	}
 
 	private int getScoreFromName(String alumniName, String linkedinName) {
-		alumniName = deAccent(alumniName);
-		linkedinName = deAccent(linkedinName);
-
-		if (alumniName.equals(linkedinName)) return 200;
-
 		ParsedName alumniParsedName = getParsedName(alumniName);
 		ParsedName linkedinParsedName = getParsedName(linkedinName);
 
+		if (alumniParsedName.equals(linkedinParsedName)) return 200;
+
 		int score = 0;
-		
+
 		if (alumniParsedName.isComposed() && !linkedinParsedName.isComposed()) {
 			linkedinParsedName.turnComposed();
 		}

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
@@ -32,7 +32,7 @@ public class MatchesFinder {
 
 		Collection<LinkedinAlumnusData> linkedinProfilesList = LinkedinDataHolder.getInstance().getLinkedinAlumniData();
 		List<PossibleMatch> selectedProfilesList = new ArrayList<>();
-		
+
 		String alumnusName = alumnus.getFullName().toUpperCase();
 
 		for (LinkedinAlumnusData linkedinProfile : linkedinProfilesList) {
@@ -42,10 +42,10 @@ public class MatchesFinder {
 			String linkedinAlumniFullName = linkedinProfile.getFullName().toUpperCase();
 
 			score += getScoreFromName(alumnusName, linkedinAlumniFullName);
-			if (score < 20) {
+			if (score == 0) {
 				continue;
 			}
-			
+
 			LOGGER.debug(String.format("Comparing: %s com %s: %d", alumnusName, linkedinAlumniFullName, score));
 			score += getScoreFromSchool(alumnus, linkedinSchoolData, school);
 
@@ -53,7 +53,7 @@ public class MatchesFinder {
 				selectedProfilesList.add(new PossibleMatch(score, linkedinProfile));
 			}
 		}
-		
+
 		return selectedProfilesList;
 	}
 
@@ -71,12 +71,12 @@ public class MatchesFinder {
 				splitedFilteredName[count++] = namePart;
 			}
 		}
-		
+
 		if (count == splitedFilteredName.length) return splitedFilteredName;
-		
+
 		String[] resizedSplitedFilteredName = new String[count];
 		System.arraycopy(splitedFilteredName, 0, resizedSplitedFilteredName, 0, count);
-		
+
 		return resizedSplitedFilteredName;
 	}
 
@@ -161,7 +161,7 @@ public class MatchesFinder {
 		if (alumniParsedName.isComposed() && !linkedinParsedName.isComposed()) {
 			linkedinParsedName.turnComposed();
 		}
-		
+
 		score += compareNames(alumniParsedName.getNames(), linkedinParsedName.getNames(), 20);
 		score += compareNames(alumniParsedName.getSurnames(), linkedinParsedName.getSurnames(), 10);
 
@@ -189,30 +189,30 @@ public class MatchesFinder {
 		}
 		return score;
 	}
-	
+
 	private List<String> getMonthRange(String startMonth, String endMonth) {
 		List<String> months = Arrays.asList("jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec");
-		
+
 		startMonth = startMonth.isEmpty() ? "" : startMonth.substring(0, 3).trim().toLowerCase();
 		endMonth = endMonth.isEmpty() ? "" : endMonth.substring(0, 3).trim().toLowerCase();
 		return months.subList((startMonth.isEmpty() ? 0 : months.indexOf(startMonth)), (endMonth.isEmpty() ? months.size() : months.indexOf(endMonth) + 1));
 	}
-	
+
 	private boolean containsMonth(List<String> months, String month) {
 		if (month.isEmpty()) return true;
 		return months.contains(month);
 	}
-	
+
 	private int compareDateRanges(DateRange linkedinSchoolDateRange, DateRange schoolDateRange) {
 		List<String> monthsRange = getMonthRange(linkedinSchoolDateRange.getStartMonth(), linkedinSchoolDateRange.getEndMonth());
-		
+
 		if (schoolDateRange.isCurrent()) {
-			if (!linkedinSchoolDateRange.getEndYear().trim().isEmpty() && Integer.parseInt(linkedinSchoolDateRange.getEndYear()) >= Integer.parseInt(schoolDateRange.getStartYear())
+			if (!linkedinSchoolDateRange.getEndYear().trim().isEmpty() && !schoolDateRange.getStartYear().trim().isEmpty() && Integer.parseInt(linkedinSchoolDateRange.getEndYear()) >= Integer.parseInt(schoolDateRange.getStartYear())
 					&& containsMonth(monthsRange, linkedinSchoolDateRange.getEndMonth())) {
 				return 10;
 			}
 		} else {
-			if (!linkedinSchoolDateRange.getStartYear().trim().isEmpty() && Integer.parseInt(linkedinSchoolDateRange.getStartYear()) >= Integer.parseInt(schoolDateRange.getStartYear()) && Integer.parseInt(linkedinSchoolDateRange.getEndYear()) <= Integer.parseInt(schoolDateRange.getEndYear())
+			if (!linkedinSchoolDateRange.getStartYear().trim().isEmpty() && !linkedinSchoolDateRange.getEndYear().trim().isEmpty() && !schoolDateRange.getEndYear().trim().isEmpty() && !schoolDateRange.getStartYear().trim().isEmpty() && Integer.parseInt(linkedinSchoolDateRange.getStartYear()) >= Integer.parseInt(schoolDateRange.getStartYear()) && Integer.parseInt(linkedinSchoolDateRange.getEndYear()) <= Integer.parseInt(schoolDateRange.getEndYear())
 					&& containsMonth(monthsRange, linkedinSchoolDateRange.getEndMonth())) {
 				return 10;
 			}
@@ -224,11 +224,11 @@ public class MatchesFinder {
 		if (linkedinSchoolDateRange == null || schoolDateRange == null) {
 			return 0;
 		}
-		
+
 		if (schoolDateRange.equals(linkedinSchoolDateRange)) {
 			return 40;
 		}
-		
+
 		return compareDateRanges(linkedinSchoolDateRange, schoolDateRange);
 	}
 
@@ -246,17 +246,17 @@ public class MatchesFinder {
 	private int getScoreFromDegreeData(Degree[] alumniDegrees, LinkedinSchoolData linkedinSchool) {
 		Level linkedinLevel = linkedinSchool.getDegreeLevel();
 		CourseName linkedinCourseName = linkedinSchool.getCourseName();
-		
+
 		if (linkedinLevel == null || linkedinCourseName == null) {
 			return 0;
 		}
-		
+
 		int score = 0;
-		
+
 		for (Degree degree : alumniDegrees) {
 			Level alumniLevel = degree.getLevel();
 			CourseName alumniCourseName = degree.getCourseName();
-			
+
 			if (alumniLevel.equals(linkedinLevel)) {
 				score += 10;
 			}

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/MatchesFinder.java
@@ -42,7 +42,7 @@ public class MatchesFinder {
 			String linkedinAlumniFullName = linkedinProfile.getFullName().toUpperCase();
 
 			score += getScoreFromName(alumnusName, linkedinAlumniFullName);
-			if (score == 0) {
+			if (score < 20) {
 				continue;
 			}
 			

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/holders/MatchesHolder.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/holders/MatchesHolder.java
@@ -5,6 +5,7 @@ import br.edu.ufcg.computacao.alumni.constants.ConfigurationPropertyDefaults;
 import br.edu.ufcg.computacao.alumni.constants.ConfigurationPropertyKeys;
 import br.edu.ufcg.computacao.alumni.constants.Messages;
 import br.edu.ufcg.computacao.alumni.core.models.PendingMatch;
+import br.edu.ufcg.computacao.alumni.core.util.PendingMatchNumberComparator;
 import br.edu.ufcg.computacao.eureca.common.exceptions.FatalErrorException;
 import br.edu.ufcg.computacao.eureca.common.exceptions.InvalidParameterException;
 import br.edu.ufcg.computacao.eureca.common.util.HomeDir;
@@ -20,7 +21,7 @@ import java.util.*;
 public class MatchesHolder {
     private Logger LOGGER = Logger.getLogger(MatchesHolder.class);
     private static final String FIELD_SEPARATOR = ",";
-    
+
     private Map<String, String> matches;
     private Collection<PendingMatch> pendingMatches;
     private String matchesFilePath;
@@ -63,11 +64,14 @@ public class MatchesHolder {
     }
     
     public synchronized void addMatch(String registration, String linkedinId) {
+        String formatedUrl = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.LINKEDIN_USER_BASE_URL_KEY) + linkedinId;
+
     	if (this.matches.containsKey(registration)) {
-    		this.matches.replace(registration, linkedinId);
+    		this.matches.replace(registration, formatedUrl);
     	} else {
-    		this.matches.put(registration, linkedinId);
+    		this.matches.put(registration, formatedUrl);
     	}
+
         try {
             this.saveMatches();
         } catch (IOException e) {
@@ -92,9 +96,9 @@ public class MatchesHolder {
     public synchronized void saveMatches() throws IOException {
         BufferedWriter csvWriter = new BufferedWriter(new FileWriter(this.matchesFilePath, false));
         for (Map.Entry<String, String> entry : this.matches.entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            csvWriter.write(key + FIELD_SEPARATOR + value + System.lineSeparator());
+            String registration = entry.getKey();
+            String linkedinId = entry.getValue();
+            csvWriter.write(registration + FIELD_SEPARATOR + linkedinId + System.lineSeparator());
         }
         csvWriter.close();
     }
@@ -112,19 +116,18 @@ public class MatchesHolder {
     private synchronized List<MatchResponse> getMatchesList() {
         List<MatchResponse> matchesList = new ArrayList<MatchResponse>();
         for (String key : this.matches.keySet()) {
-            matchesList.add(new MatchResponse(key, this.matches.get(key)));
+            String fullName = AlumniHolder.getInstance().getAlumnusName(key);
+            matchesList.add(new MatchResponse(key, fullName, this.matches.get(key)));
         }
         return matchesList;
     }
 
-    public synchronized  List<MatchResponse> getAlumnusMatches(String registration) {
-        List<MatchResponse> matchesList = new ArrayList<MatchResponse>();
-        for (String key : this.matches.keySet()) {
-            if(key.equals(registration)) {
-                matchesList.add(new MatchResponse(key, this.matches.get(key)));
-            }
-        }
-        return matchesList;
+    public synchronized MatchResponse getAlumnusMatches(String registration) {
+        String linkedinId = this.matches.get(registration);
+        if (linkedinId == null) return null;
+
+        String fullName = AlumniHolder.getInstance().getAlumnusName(registration);
+        return new MatchResponse(registration, fullName, registration);
     }
 
     public synchronized Map<String, String> getMatches() {
@@ -148,7 +151,9 @@ public class MatchesHolder {
     }
 
     private synchronized List<PendingMatch> getPendingMatches() {
-        return new LinkedList<>(this.pendingMatches);
+        List<PendingMatch> list = new LinkedList<>(this.pendingMatches);
+        list.sort(new PendingMatchNumberComparator());
+        return list;
     }
 
     public synchronized void setPendingMatches(Collection<PendingMatch> newPendingMatches) {

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/MatchesFinderProcessor.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/MatchesFinderProcessor.java
@@ -75,13 +75,13 @@ public class MatchesFinderProcessor extends Thread {
 
 		while (isActive) {
 			try {
-				Map<String, String> consolidatedMatches = MatchesHolder.getInstance().getMatches();
+				Set<String> consolidatedMatches = MatchesHolder.getInstance().getMatches().keySet();
 				Collection<UfcgAlumnusData> alumni = AlumniHolder.getInstance().getAlumniData();
 				Collection<PendingMatch> newPendingMatches = new LinkedList<>();
 			
 				for (UfcgAlumnusData alumnus : alumni) {
 					String registration = alumnus.getRegistration();
-					if (!consolidatedMatches.containsKey(registration)) {
+					if (!consolidatedMatches.contains(registration)) {
 						LOGGER.debug(String.format(Messages.FINDING_MATCHES_FOR_S, alumnus.getFullName()));
 						Collection<PossibleMatch> possibleMatches =
 								MatchesFinder.getInstance().findMatches(alumnus, schoolName);

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/StatisticsProcessor.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/StatisticsProcessor.java
@@ -58,10 +58,8 @@ public class StatisticsProcessor extends Thread {
 	}
 	
 	private int getNumberMappedAlumni(Collection<UfcgAlumnusData> alumni) {
-		Map<String, String> matches = MatchesHolder.getInstance().getMatches();
-		
 		Set<String> alumniRegistrations = alumni.stream().map(UfcgAlumnusData::getRegistration).collect(Collectors.toSet());
-		Set<String> matchesRegistrations = matches.keySet();
+		Set<String> matchesRegistrations = MatchesHolder.getInstance().getMatches().keySet();
 		
 		Set<String> mappedAlumni = new HashSet<>(matchesRegistrations);
 		mappedAlumni.retainAll(alumniRegistrations);
@@ -71,9 +69,7 @@ public class StatisticsProcessor extends Thread {
 	
 	private int getNumberTypeEmployed(Collection<UfcgAlumnusData> alumni, EmployerType type) {
 		Collection<EmployerResponse> employers = EmployersHolder.getInstance().getClassifiedEmployers(type);
-		Map<String, String> matches = MatchesHolder.getInstance().getMatches();
-		
-		
+
 		Collection<String> employersCompanyNames = employers.stream()
 				.map(EmployerResponse::getName)
 				.collect(Collectors.toList());
@@ -81,7 +77,7 @@ public class StatisticsProcessor extends Thread {
 		int num = 0;
 		for (UfcgAlumnusData alumnus : alumni) {
 			String alumnusFullName = alumnus.getFullName();
-			String linkedinUrl = matches.get(alumnus.getRegistration());
+			String linkedinUrl = MatchesHolder.getInstance().getLinkedinId(alumnus.getRegistration());
 			
 			CurrentJob currentJob = LinkedinDataHolder.getInstance().getAlumnusCurrentJob(alumnusFullName, linkedinUrl);
 			if (employersCompanyNames.contains(currentJob.getCurrentJob())) {

--- a/src/test/java/br/edu/ufcg/computacao/alumni/api/http/request/MatchTest.java
+++ b/src/test/java/br/edu/ufcg/computacao/alumni/api/http/request/MatchTest.java
@@ -135,8 +135,8 @@ public class MatchTest {
         String alumnusMatchesEndpoint = MATCH_ENDPOINT + "/?registration=";
 
         List<MatchResponse> list = new ArrayList();
-        list.add(new MatchResponse("1","1"));
-        list.add(new MatchResponse("2", "2"));
+        list.add(new MatchResponse("1","1", "a"));
+        list.add(new MatchResponse("2", "2", "b"));
 
         Mockito.doReturn(list).when(this.facade)
                 .getAlumnusMatches(Mockito.anyString(), Mockito.anyString());


### PR DESCRIPTION
Todos as classes holders estavam guardando os dados em mapas, exceto o AlumniHolder (a estrutura de dados era um array), então tomei a liberdade de padronizar para um mapa. Foi adicionado também no MatchResponse o nome do aluno, para que o frontend possa mostrar o nome na tela de associados sem precisar chamar outra rota (obs: a escrita no arquivo matches.db nao muda, muda apenas a leitura). Foi também criada uma variável de configuração "linkedin_user_url", pois na hora de realizar o match os dados são passados pelos query params, que não permite que seja passado um link, então foi criada um método em LinkedinAlumnusData que retorna apenas o nome do usuário, sem o "https://www...", que será utilizado pelo frontend e, quando for realizado o match, o backend faz a concatenação com essa parte que ficaria faltando e escreve o link completo no matches.db.