### PR TITLE
implementing data persistence to unclassified employers

### DIFF
--- a/src/main/java/br/edu/ufcg/computacao/alumni/constants/ConfigurationPropertyDefaults.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/constants/ConfigurationPropertyDefaults.java
@@ -4,7 +4,7 @@ public class ConfigurationPropertyDefaults {
     // ALUMNI CONF DEFAULTS
     public static final String DEFAULT_LINKEDIN_INPUT_FILE_NAME = "linkedin.input";
     public static final String DEFAULT_MATCHES_FILE_NAME = "matches.db";
-    public static final String DEFAULT_EMPLOYER_CLASSIFICATION_FILE_NAME = "employers.db";
+    public static final String DEFAULT_CLASSIFIED_EMPLOYER_FILE_NAME = "employers.db";
     public static final String DEFAULT_CONSOLIDATED_EMPLOYERS_FILE_NAME = "employers.consolidated.db";
     public static final String BUILD_NUMBER = "[testing mode]";
 }

--- a/src/main/java/br/edu/ufcg/computacao/alumni/constants/ConfigurationPropertyKeys.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/constants/ConfigurationPropertyKeys.java
@@ -13,7 +13,7 @@ public class ConfigurationPropertyKeys {
     public static final String BACKEND_PORT_KEY = "backend_port";
     public static final String AUTHORIZATION_PLUGIN_CLASS_KEY = "authorization_plugin_class";
     public static final String SCHOOL_INPUT_KEY = "school_input";
-    public static final String EMPLOYERS_FILE_KEY = "employers_file";
+    public static final String CLASSIFIED_EMPLOYERS_FILE_KEY = "employers_file";
     public static final String CONSOLIDATED_EMPLOYERS_FILE_KEY = "consolidated_employers_file";
     public static final String USERNAME = "username";
     public static final String PASSWORD = "password";

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/EmployerMatcher.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/EmployerMatcher.java
@@ -36,7 +36,7 @@ public class EmployerMatcher {
             Matcher nameMatcher = namePattern.matcher(consolidatedEmployer.getName());
 
             if (nameMatcher.find()) {
-                LOGGER.info(String.format("%s is a possible match for %s\n", consolidatedEmployer.getName(), unknownEmployer.getName()));
+//                LOGGER.info(String.format("%s is a possible match for %s\n", consolidatedEmployer.getName(), unknownEmployer.getName()));
                 possibleEmployers.add(consolidatedEmployer);
             }
         }

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/EmployerMatcher.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/EmployerMatcher.java
@@ -36,7 +36,6 @@ public class EmployerMatcher {
             Matcher nameMatcher = namePattern.matcher(consolidatedEmployer.getName());
 
             if (nameMatcher.find()) {
-//                LOGGER.info(String.format("%s is a possible match for %s\n", consolidatedEmployer.getName(), unknownEmployer.getName()));
                 possibleEmployers.add(consolidatedEmployer);
             }
         }

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/EmployerFinderProcessor.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/EmployerFinderProcessor.java
@@ -8,10 +8,8 @@ import br.edu.ufcg.computacao.alumni.core.holders.LinkedinDataHolder;
 import br.edu.ufcg.computacao.alumni.core.models.EmployerModel;
 import br.edu.ufcg.computacao.alumni.core.models.EmployerType;
 import br.edu.ufcg.computacao.alumni.core.models.LinkedinJobData;
-import br.edu.ufcg.computacao.alumni.core.models.UnknownEmployer;
 import org.apache.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,8 +28,10 @@ public class EmployerFinderProcessor extends Thread {
 		while (isActive) {
 			try {
 				Map<String, ConsolidatedEmployer> classifiedEmployers = EmployersHolder.getInstance().getMapClassifiedEmployers();
+				Map<String, ConsolidatedEmployer> unclassifiedEmployers = EmployersHolder.getInstance().getMapUnclassifiedEmployers();
 				Map<String, ConsolidatedEmployer> newEmployers = new HashMap<>();
 				Map<String, EmployerModel> unknownEmployers = new HashMap<>();
+
 				Collection<LinkedinAlumnusData> linkedinProfiles = LinkedinDataHolder.getInstance().getLinkedinAlumniData();
 
 				for (LinkedinAlumnusData profile : linkedinProfiles) {
@@ -42,13 +42,12 @@ public class EmployerFinderProcessor extends Thread {
 						String linkedinId = job.getCompanyUrl();
 
 						if (!classifiedEmployers.containsKey(linkedinId)) {
-							if (!job.getEmployer().isConsolidated()) {
-								unknownEmployers.put(job.getCompanyUrl(), job.getEmployer());
-							} else {
+						  	if (!job.getEmployer().isConsolidated()) {
+								unknownEmployers.put(linkedinId, job.getEmployer());
+							} else if (!unclassifiedEmployers.containsKey(linkedinId)) {
 								newEmployers.put(linkedinId, new ConsolidatedEmployer(name, linkedinId, EmployerType.UNDEFINED));
 								LOGGER.debug(String.format(Messages.ADD_EMPLOYER_S, name));
 							}
-
 						}
 					}
 				}

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/MatchesFinderProcessor.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/MatchesFinderProcessor.java
@@ -86,7 +86,7 @@ public class MatchesFinderProcessor extends Thread {
 								MatchesFinder.getInstance().findMatches(alumnus, schoolName);
 
 						if (!possibleMatches.isEmpty()) {
-//							LOGGER.info(String.format(Messages.FOUND_D_POSSIBLE_MATCHES_FOR_S, possibleMatches.size(), alumnus.getFullName()));
+							LOGGER.debug(String.format(Messages.FOUND_D_POSSIBLE_MATCHES_FOR_S, possibleMatches.size(), alumnus.getFullName()));
 							newPendingMatches.add(new PendingMatch(alumnus, possibleMatches));
 						}
 					}

--- a/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/MatchesFinderProcessor.java
+++ b/src/main/java/br/edu/ufcg/computacao/alumni/core/processors/MatchesFinderProcessor.java
@@ -86,7 +86,7 @@ public class MatchesFinderProcessor extends Thread {
 								MatchesFinder.getInstance().findMatches(alumnus, schoolName);
 
 						if (!possibleMatches.isEmpty()) {
-							LOGGER.info(String.format(Messages.FOUND_D_POSSIBLE_MATCHES_FOR_S, possibleMatches.size(), alumnus.getFullName()));
+//							LOGGER.info(String.format(Messages.FOUND_D_POSSIBLE_MATCHES_FOR_S, possibleMatches.size(), alumnus.getFullName()));
 							newPendingMatches.add(new PendingMatch(alumnus, possibleMatches));
 						}
 					}


### PR DESCRIPTION
Foi implementada a persistência dos dados dos empregadores não classificados no arquivo employers.consolidated.db (acredito que um nome melhor para colocar nesse arquivo seria 'employers.unclassified.db', mas não o fiz sem consultar, pois teria que mudar o arquivo alumni.conf e o nome do arquivo de empregadores). 

OBS: Quando um empregador desconhecido é setado como consolidado, ao reiniciar a API ele volta a ser desconhecido, pois ao ler os dados dos empregadores nos perfis do Linkedin, o empregador vai estar com a url antiga, pois não foi feita -ainda- a persistência desses dados nos objetos LinkedinAlumnusData